### PR TITLE
migrate aliases into their own collection

### DIFF
--- a/lib/migrations/2016-9-23-move_aliases.rb
+++ b/lib/migrations/2016-9-23-move_aliases.rb
@@ -1,0 +1,54 @@
+require 'mongo'
+require 'optparse'
+
+module PagerBot
+  class MoveAliasesMigration
+      def db
+        return @db unless @db.nil?
+        if ENV['MONGODB_URI']
+          client = Mongo::MongoClient.from_uri(ENV['MONGODB_URI'])
+          db_name = ENV['MONGODB_URI'][%r{/([^/\?]+)(\?|$)}, 1]
+        else
+          client = Mongo::MongoClient.new
+          db_name = "pagerbot"
+        end
+
+        @db = client.db(db_name)
+      end
+        
+      # grab all users and schedules
+      # for each one, grab its aliases,
+      # and spit that into another collection, keyed on alias
+      # {_id: alias, pagerduty_id: PDID, type: user/schedule}
+      def update_collection(collection, type, real)
+        result = db[collection].find({})
+        result.each do |pd_obj|
+          aliases = pd_obj['aliases'] || []
+          aliases.each do |ali|
+            if real
+              db[collection].insert({_id: ali, pagerduty_id: pd_obj['id'], type: type})
+            else
+              puts("Would have inserted #{ali} into the database for #{type} #{pd_obj['name']}")
+            end
+          end
+        end
+      end
+
+      def run!(real=false)
+        update_collection('users', 'user', real)
+        update_collection('schedules', 'schedule', real)
+      end
+  end
+end
+
+if __FILE__ == $0
+  options = {}
+  OptionParser.new do |opts|
+    opts.banner = "Usage: 2016-9-23-move-aliases.rb [options]"
+
+    opts.on("-r", "--real", "Run the migration with side effects") do
+      options[:real] = true
+    end
+  end.parse!
+  PagerBot::MoveAliasesMigration.new.run!(options[:real])
+end

--- a/lib/pagerbot/plugin/plugin_manager.rb
+++ b/lib/pagerbot/plugin/plugin_manager.rb
@@ -62,17 +62,17 @@ module PagerBot
       end
       class_name = plugin_class plugin_name
       require File.join(File.dirname(__FILE__), plugin_name)
-      clazz = class_from_string(class_name)
+      klass = class_from_string(class_name)
 
       ret = {}
-      if clazz.responds_to? :manual
-        ret = clazz.manual
+      if klass.responds_to? :manual
+        ret = klass.manual
       end
       ret.merge({
         name: plugin_name,
-        description: clazz.description,
-        required_fields: clazz.required_fields,
-        required_plugins: clazz.required_plugins || []
+        description: klass.description,
+        required_fields: klass.required_fields,
+        required_plugins: klass.required_plugins || []
       })
     end
 


### PR DESCRIPTION
This is part of a process to upgrade pagerbot to the v2 PagerDuty API.

Next steps:
- [ ] update the code to use the separate aliases collection
- [ ] upload the pagerduty code to use the new v2 API
- [ ] blow away the existing users and schedule table, and reload data from pagerduty
- [ ] update the `call` plugin to send incidents directly to a service (instead of going via mailgun)

cc @rhwlo
